### PR TITLE
Fix README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,16 @@ Follow these steps to get the OpenRouter Streamlit Chat app up and running on yo
 ```bash
 git clone https://github.com/YOUR_USERNAME/YOUR_REPOSITORY_NAME.git
 cd YOUR_REPOSITORY_NAME
+```
+
+### 3. Install Dependencies
+
+```bash
+pip install streamlit requests
+```
+
+### 4. Run the App
+
+```bash
+streamlit run streamlit_app.py
+```


### PR DESCRIPTION
## Summary
- close unclosed code block in README
- document how to install dependencies and run the app

## Testing
- `python -m py_compile streamlit_app.py`

------
https://chatgpt.com/codex/tasks/task_e_683f99474420832eb9a6ab6a2de30c2b