### PR TITLE
Fix README code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,4 @@ Follow these steps to get the OpenRouter Streamlit Chat app up and running on yo
 ```bash
 git clone https://github.com/YOUR_USERNAME/YOUR_REPOSITORY_NAME.git
 cd YOUR_REPOSITORY_NAME
+```


### PR DESCRIPTION
## Summary
- close the `bash` code block in README

## Testing
- `python3 -m py_compile streamlit_app.py`

------
https://chatgpt.com/codex/tasks/task_e_683f9b60a55c832ea5ec79d44757aaec