### PR TITLE
Add pytest config and tests for token formatting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.pytest.ini_options]
+addopts = "-ra"
+python_files = ["test_*.py", "*_test.py"]

--- a/tests/test_format_token_count.py
+++ b/tests/test_format_token_count.py
@@ -1,0 +1,43 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import pytest
+
+from streamlit_app import format_token_count
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (0, "0"),
+        (5, "5"),
+        (999, "999"),
+        (None, "N/A"),
+    ],
+)
+def test_format_token_count_below_thousand(value, expected):
+    assert format_token_count(value) == expected
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (1000, "1k"),
+        (1500, "1.5k"),
+        (12000, "12k"),
+        (999999, "1000k"),
+    ],
+)
+def test_format_token_count_thousands(value, expected):
+    assert format_token_count(value) == expected
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (1000000, "1M"),
+        (1500000, "1.5M"),
+        (5000000, "5M"),
+    ],
+)
+def test_format_token_count_millions(value, expected):
+    assert format_token_count(value) == expected


### PR DESCRIPTION
## Summary
- configure pytest via `pyproject.toml`
- add tests for `format_token_count`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f9b659298832ebfaa753e4b9b8cdc